### PR TITLE
Mark previous versions as deprecated

### DIFF
--- a/recipes/rapidcheck/all/conandata.yml
+++ b/recipes/rapidcheck/all/conandata.yml
@@ -5,6 +5,12 @@ sources:
   "20210107":
     url: "https://github.com/emil-e/rapidcheck/archive/37bcab858dfc398634d409c973363088703ba96e.zip"
     sha256: "35433d0417fb945abe2b56b720b03d6d92da1188e760c50662c243dac42a6717"
-  "20210702":
+  "cci.20210702":
     url: "https://github.com/emil-e/rapidcheck/archive/33d15a858e3125f5af61a655f390f1cbc2f272ba.zip"
     sha256: "521c9b163f0018ea6379513e0c674d520b9da66fdb8df73a7a98b04ea2358e69"
+  "cci.20210107":
+    url: "https://github.com/emil-e/rapidcheck/archive/37bcab858dfc398634d409c973363088703ba96e.zip"
+    sha256: "35433d0417fb945abe2b56b720b03d6d92da1188e760c50662c243dac42a6717"
+  "cci.20200131":
+    url: "https://github.com/emil-e/rapidcheck/archive/258d907da00a0855f92c963d8f76eef115531716.zip"
+    sha256: "87bfbdceaa09e7aaaf70b2efd0078e93323dd8abdad48c57e9f23bfd84174a75"

--- a/recipes/rapidcheck/all/conanfile.py
+++ b/recipes/rapidcheck/all/conanfile.py
@@ -51,6 +51,9 @@ class RapidcheckConan(ConanFile):
         if self.settings.compiler == "Visual Studio" and self.options.shared:
             raise ConanInvalidConfiguration("shared is not supported using Visual Studio")
 
+        if 'cci' not in self.version:
+            raise ConanInvalidConfiguration("This version has been deprecated in favor of '{}/cci.{}'".format(self.name, self.version))
+
     def source(self):
         tools.get(**self.conan_data["sources"][self.version],
                   destination=self._source_subfolder, strip_root=True)

--- a/recipes/rapidcheck/config.yml
+++ b/recipes/rapidcheck/config.yml
@@ -3,5 +3,9 @@ versions:
     folder: all
   "20210107":
     folder: all
-  "20210702":
+  "cci.20210702":
+    folder: all
+  "cci.20210107":
+    folder: all
+  "cci.20200131":
     folder: all


### PR DESCRIPTION
Taking into account review by @madebr here: https://github.com/conan-io/conan-center-index/pull/7037, IMO it's better if we create a recipe revision invalidating the versions without `cci.` prefix so people already using them will get a message and can migrate.

